### PR TITLE
Added setup.py to allow installing with pip and some basic documentation about how to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,32 @@ Django model fields for storing color values in different formats including hex,
 
 TODO
 
+
+Usage
+======
+
+* 1. Add 'color_utils' to your installed apps:
+
+INSTALLED_APPS = (
+  ...
+
+  'color_utils',
+
+  ...
+)
+
+* 2. In your forms.py file override form widgets with widgets from color_utils. For example if using model forms:
+
+```python
+from django.forms import ModelForm
+from . import models
+
+from color_utils import widgets as color_widgets
+
+class MyColorfulModelForm(ModelForm):
+    class Meta:
+        model = models.MyColorfulModel
+        widgets = {
+            'my_color_field': color_widgets.HTML5ColorInput(),
+        }
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Usage
 
 * 1. Add 'color_utils' to your installed apps:
 
+```python
 INSTALLED_APPS = (
   ...
 
@@ -42,6 +43,7 @@ INSTALLED_APPS = (
 
   ...
 )
+```
 
 * 2. In your forms.py file override form widgets with widgets from color_utils. For example if using model forms:
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='django-color-utils',
+    version='0.1.0',
+    description='Collection of color picker widgets and color database model fields for Django.',
+    long_description=open('README.md').read(),
+    author='Tim Church',
+    url='hhttps://github.com/timchurch/django-color-utils',
+    include_package_data=True,
+    package_data={'': ['README.md']},
+    packages=['color_utils']
+)


### PR DESCRIPTION
Title says it all. I added simple setup.py file to allow installing with pip. Now you can add this package to your requirements.txt file and it will work:

```
-e git+git@github.com:mentholi/django-color-utils.git@1e7492de71dcd6b104739754fcd980197fc35167#egg=django-color-utils
```

If package doesn't contain setup.py file installation will fail and users need to manually clone the repository.

Also added very simple documentation to README.md about how to use this. 
